### PR TITLE
Remove Command

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ of the available commands is displayed below here👇
 | `insert` | insert a new author into the database |
 | `extract` | extracts an author from the database and sets expiration date |
 | `view` | print to screen the inserted authors or the extracted one |
+| `remove` | removes author from the database |
 
 Check [what's next](#whats-next) for more info about coming patches.
 

--- a/other/user_manual.md
+++ b/other/user_manual.md
@@ -2,6 +2,7 @@
 
 - [Insert](#insert)
 - [Extract](#extract)
+- [Remove](#remove)
 - [View](#view)
 
 ## Insert
@@ -35,3 +36,8 @@ If the input command is incorrect the following screen will be shown:
 When in *view all*, in order to stop scrolling authors input `q` when the input appears:
 
 ![Quit-View](./images/tutorial/quit_view.png) 
+
+## Remove
+
+You can remove an author, if already present in the database, by using the *remove* action.
+ 

--- a/src/author_picker.c
+++ b/src/author_picker.c
@@ -192,6 +192,8 @@ boolean search_author(FILE* fp, char* auth){
     return false;
 }   
 
+#define MSG_INPUT_ERROR ("\n[INPUT ERROR]: the input has null length, please consider writing at least one character!\n")
+
 void insert_author(char* author_name) {
     // At this point the buffer contains the name of the author
     // this means that 2 actions are to be performed:
@@ -202,7 +204,11 @@ void insert_author(char* author_name) {
     // 
     // THE FIRST LINE OF THE FILE WILL CONTAIN THE AUTHOR THAT WAS LAST EXTRACTED
 
-    assert( strlen(author_name) != 0 ); // This has to be changed into an print to screen and early return
+    if(len_of_str(author_name, AUTHOR_LEN) == 0){
+        fprintf(stderr, "\n[INPUT ERROR]: the input has null length, please consider writing at least one character!\n");
+        return;
+    }
+
     char* auth_name = trim(author_name);
     
     FILE* fp = fopen(datafile, "r+");
@@ -512,7 +518,11 @@ int bytes_to_end(FILE* fp){
 }
 
 void remove_author(char* auth_name){
-    assert(strlen(auth_name) != 0);
+    
+    if(len_of_str(auth_name, AUTHOR_LEN) == 0) {
+        fprintf(stderr, MSG_INPUT_ERROR);
+        return;
+    }
 
     FILE* fp = fopen(datafile, "r+");
     if (!fp) fatal("in remove_author() while opening file");
@@ -531,9 +541,9 @@ void remove_author(char* auth_name){
 
     fseek(fp, 0, SEEK_SET);
     int bytes_file_size = bytes_to_end(fp);
-    int bytes_first_line =  bytes_file_size - (auth_bytes + 1 + cpy_bytes);
-    truncate(datafile, bytes_first_line);
-    fseek(fp, bytes_first_line, SEEK_SET);
+    int bytes_to_save =  bytes_file_size - (auth_bytes + 1 + cpy_bytes);
+    truncate(datafile, bytes_to_save);
+    fseek(fp, bytes_to_save, SEEK_SET);
     fwrite(lines_after->buf, lines_after->bytes, 1, fp);
     free(lines_after->buf);
     free(lines_after);

--- a/src/author_picker.h
+++ b/src/author_picker.h
@@ -4,15 +4,24 @@
 #define AUTHOR_LEN 50
 
 /*
+    # Insert
     Appends the given author's name to the file.
 
-    # INPUT
+    ## Input
+    author_name -> string to insert
 
-    The author's name read from the user input.
+    If the passed string has a null lenght (=0), this function
+    notifies the user and returns without performing any further action.
+
+    ## Deallocation
+    This function doesn't deallocate the input as it cannot determine if it
+    is heap or stack allocated
 */
 void insert_author(char* author_name);
 
 /*
+    # Extract
+
     Highlights a random author's name from those inserted into the file
     rewriting the name at the first line.
     The first line is formatted with the name of the author and the time and day 
@@ -21,14 +30,24 @@ void insert_author(char* author_name);
 void extract_author();
 
 /*
-    Searches and removes from the file the selected author's name.
+    # Remove
+    Searches and removes selected author's name.
+
+    ## Input
+    author_name -> string to remove
+
+    If the given string has a null length (=0) then the function
+    notifies the user and returns without performing any further action.
 */
 void remove_author(char* author_name);
 
 /*
+    # View
+
     Prints out all of the authors currently inserted
 */
 void view();
+
 // void find_author(char* author_name);
 
 #endif

--- a/src/author_picker.h
+++ b/src/author_picker.h
@@ -20,10 +20,10 @@ void insert_author(char* author_name);
 */
 void extract_author();
 
-// /*
-//     Searches and removes from the file the selected author's name.
-// */
-// void remove_author(char* author_name);
+/*
+    Searches and removes from the file the selected author's name.
+*/
+void remove_author(char* author_name);
 
 /*
     Prints out all of the authors currently inserted

--- a/src/main.c
+++ b/src/main.c
@@ -5,19 +5,21 @@
 #include "helper_lib.h"
 
 #define A 2
-#define MENU ("\nWelcome to Author Picker:\n-. [I]nsert an author\n-. [E]xtract an author\n-. [V]iew\n-. [Q]uit\n")
+#define MENU ("\nWelcome to Author Picker:\n-. [I]nsert an author\n-. [E]xtract an author\n-. [V]iew\n-. [R]emove\n-. [Q]uit\n")
 
-int parse_input(char action, char* buf){
+int parse_input(char action){
     assert('A' <= action && action <= 'z');
+
+    char buffer[AUTHOR_LEN] = {'\0'};
 
     switch (conv_to_lower(action))
     {
     case 'i':
         printf("Insert the name of the author: ");
-        read_line(buf, AUTHOR_LEN);
-        str_to_lower(buf);
-        printf("Inserting %s...\n", buf);
-        insert_author(buf);
+        read_line(buffer, AUTHOR_LEN);
+        str_to_lower(buffer);
+        printf("Inserting %s...\n", buffer);
+        insert_author(buffer);
         return 1;
     case 'e':
         printf("Extracting...\n");
@@ -25,6 +27,13 @@ int parse_input(char action, char* buf){
         return 1;
     case 'v':
         view();
+        return 1;
+    case 'r':
+    printf("Insert the name of the author: ");
+        read_line(buffer, AUTHOR_LEN);
+        str_to_lower(buffer);
+        printf("Remove %s...\n", buffer);
+        remove_author(buffer);
         return 1;
     case 'q': return 0;
     default:
@@ -42,14 +51,13 @@ void check_config(){
 int main(int argc, char** argv) {
     check_config();
     char action;
-    char buffer[AUTHOR_LEN] = {'\0'};
     int running = 1;
     while (running) {
         printf(MENU);
         printf(INPUT);
         action = getchar() + '\0';
         flush_stdin();
-        running = parse_input(action, buffer);
+        running = parse_input(action);
     }
     return 0;
 }


### PR DESCRIPTION
It is now possible to remove an author directly from terminal. The remotion locates only completely matching strings: the limitation are those of the insertion. Like insertion, right now the remove action fails and closes if a buffer of length 0 is passed.
